### PR TITLE
Add Github workflow to check code quality

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -1,0 +1,28 @@
+name: Check Code Quality
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Check Code Quality
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+    - name: Install Package
+      run: pip install '.[dev]'
+    - name: Check Code Quality
+      run: |
+        black --check .
+        isort --check .


### PR DESCRIPTION
# Add Github workflow to check code quality

Add a Github workflow to check code quality using `black` and `isort` on 
* push
* pull-request
* dispatch

In order to protect the code base we should add branch [protections rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) for `main`. I'd recommend to enable (at least)
* Require a pull request before merging (as soon as @maxvanspengler has pushed all relevant code).
* Require status checks to pass before merging (can be enabled now).
* Require branches to be up to date before merging (can be enabled now).

To see the workflows in action, click on "Show all checks" and "Details" on the merge button below.