### PR TITLE
Fix typo in error message

### DIFF
--- a/hypdl/utils/layer_utils.py
+++ b/hypdl/utils/layer_utils.py
@@ -9,7 +9,7 @@ from hypdl.tensors import ManifoldTensor
 def check_if_manifolds_match(layer: Module, input: ManifoldTensor) -> None:
     if layer.manifold != input.manifold:
         raise ValueError(
-            f"Manifold of {layer.__class__.__name__} layer is {layer.manifold}"
+            f"Manifold of {layer.__class__.__name__} layer is {layer.manifold} "
             f"but input has manifold {input.manifold}"
         )
 
@@ -22,7 +22,7 @@ def check_if_man_dims_match(layer: Module, man_dim: int, input: ManifoldTensor) 
 
     if input.man_dim != new_man_dim:
         raise ValueError(
-            f"Layer of type {layer.__class__.__name__} expects the manifold dimension to be {man_dim},"
+            f"Layer of type {layer.__class__.__name__} expects the manifold dimension to be {man_dim}, "
             f"but input has manifold dimension {input.man_dim}"
         )
 


### PR DESCRIPTION
# Fix typo in error message

* Add whitespace and fix the error messgage.


Before:
```
Manifold of HConvolution2d layer is PoincareBallbut input has manifold Euclidean.
```
```
Layer of type HConvolution2d expects the manifold dimension to be 1,but input has manifold dimension 3
```

After:
```
Manifold of HConvolution2d layer is PoincareBall but input has manifold Euclidean.
```
```
Layer of type HConvolution2d expects the manifold dimension to be 1, but input has manifold dimension 3
```