### PR TITLE
Add example docstring for HConvolution2d

### DIFF
--- a/hypdl/nn/modules/convolution.py
+++ b/hypdl/nn/modules/convolution.py
@@ -25,7 +25,7 @@ class HConvolution2d(Module):
         padding:
             Padding added to all four sides of the input. Default: 0
         id_init:
-            TODO(Philipp, 05/23): What is this for?
+            Use identity initialization (True) if appropriate or use HNN++ initialization (False).
 
     """
 


### PR DESCRIPTION
# Add example docstring for HConvolution2d

* Adds an example docstring for `HConvolution2d` following the [Google styleguide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
* These docstrings can be used to autogenerate documentation using [sphinx's napoleon extension](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html).
* @maxvanspengler we could also use numpy style docstrings I guess it's just a matter of preference, wdyt?

TODO:
- [x] What is `id_init`? 