### PR TITLE
Add option to build docs without running tutorials

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,10 @@ BUILDDIR      = build
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Build the docs without running the python tutorials
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 	
 
 .PHONY: help Makefile

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,8 @@ to see open issues and share your feedback!
    :maxdepth: 1
 
    tutorials/cifar10_tutorial.rst
+   tutorials/cifar10_resnet_tutorial.rst
+   tutorials/poincare_embeddings_tutorial.rst
 
 
 .. toctree::


### PR DESCRIPTION
# Add option to build docs without running tutorials

@maxvanspengler this is the fix we talked about.