### PR TITLE
Don't run tutorials when building the docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,10 @@ BUILDDIR      = build
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Build the docs without running the python tutorials
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 	
 
 .PHONY: help Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+PLOT_GALLERY  ?= 0
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -22,4 +23,4 @@ html-noplot:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D plot_gallery=$(PLOT_GALLERY)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,15 +1,18 @@
 # Build the Docs
 `sphinx` provides a Makefile, so to build the `html` documentation, simply type:
 ```
-make html
+PLOT_GALLERY=1 make html
 ```
 
 Or, alternatively
 ```
-SPHINXBUILD="python3 -m sphinx.cmd.build" make html
+SPHINXBUILD="python3 -m sphinx.cmd.build" PLOT_GALLERY=1 make html
 ```
 
-To build docs without running python files (tutorials) use the `html-noplot` rule.
+To build docs without running python files (tutorials) use:
+```
+make html
+```
 
 You can browse the docs by opening the generated html files in the `docs/build` directory
 with a browser of your choice.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,8 @@ to see open issues and share your feedback!
    :maxdepth: 1
 
    tutorials/cifar10_tutorial.rst
+   tutorials/cifar10_resnet_tutorial.rst
+   tutorials/poincare_embeddings_tutorial.rst
 
 
 .. toctree::


### PR DESCRIPTION
# Don't run tutorials when building the docs

Use an environment variable to enable/disable running the tutorials when building the docs. Update the README accordingly.