### PR TITLE
Make no_plot default in conf.py

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,10 @@ BUILDDIR      = build
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Build the docs without running the python tutorials
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 	
 
 .PHONY: help Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,20 +7,14 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
-PLOT_GALLERY  ?= 0
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-# Build the docs without running the python tutorials
-html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
-	
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D plot_gallery=$(PLOT_GALLERY)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,11 @@
 # Build the Docs
 `sphinx` provides a Makefile, so to build the `html` documentation, simply type:
-```
-PLOT_GALLERY=1 make html
+```make html
 ```
 
 Or, alternatively
 ```
-SPHINXBUILD="python3 -m sphinx.cmd.build" PLOT_GALLERY=1 make html
-```
-
-To build docs without running python files (tutorials) use:
-```
-make html
+SPHINXBUILD="python3 -m sphinx.cmd.build" make html
 ```
 
 You can browse the docs by opening the generated html files in the `docs/build` directory

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,8 @@ sphinx_gallery_conf = {
     "examples_dirs": "../../tutorials",
     "gallery_dirs": "tutorials/",
     "filename_pattern": "",
+    # TODO(Philipp, 06/23): Figure out how we can build and host tutorials on RTD.
+    "plot_gallery": "False",
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,8 @@ to see open issues and share your feedback!
    :maxdepth: 1
 
    tutorials/cifar10_tutorial.rst
+   tutorials/cifar10_resnet_tutorial.rst
+   tutorials/poincare_embeddings_tutorial.rst
 
 
 .. toctree::


### PR DESCRIPTION
# Make no_plot default in conf.py

Remove all the flags from before and instead set `no_plot` to `False` in the config. This way RDT should recognize it, too.

With this PR we at least get the tutorials for now even though they didn't run through.