### PR TITLE
46 riemannianadam dont workattempting to apply the torch function function tensor  hash   on a manifoldparameter

### DIFF
--- a/hypll/tensors/manifold_tensor.py
+++ b/hypll/tensors/manifold_tensor.py
@@ -104,6 +104,10 @@ class ManifoldTensor:
                 break
 
         return ManifoldTensor(data=new_tensor, manifold=self.manifold, man_dim=output_man_dim)
+    
+    def __hash__(self):
+        # TODO: need to change the hash based on the other ManifoldTensor properties as well.
+        return hash(self.tensor)
 
     def cpu(self) -> ManifoldTensor:
         """Returns a copy of this object with self.tensor in CPU memory."""

--- a/hypll/tensors/manifold_tensor.py
+++ b/hypll/tensors/manifold_tensor.py
@@ -104,7 +104,7 @@ class ManifoldTensor:
                 break
 
         return ManifoldTensor(data=new_tensor, manifold=self.manifold, man_dim=output_man_dim)
-    
+
     def __hash__(self):
         # TODO: need to change the hash based on the other ManifoldTensor properties as well.
         return hash(self.tensor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hypll"
 description = "A framework for hyperbolic learning in PyTorch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
     "torch",
 ]


### PR DESCRIPTION
Added a hash method to ManifoldTensors by simply taking the hash from the tensor attribute. This may lead to some problems down the line and ideally we have a hash function that also takes the other attributes into account. However, that may take some more time, so we can address it in a different issue.