### PR TITLE
Implement __hash__ for tensors as in torch

### DIFF
--- a/hypll/tensors/manifold_tensor.py
+++ b/hypll/tensors/manifold_tensor.py
@@ -106,8 +106,13 @@ class ManifoldTensor:
         return ManifoldTensor(data=new_tensor, manifold=self.manifold, man_dim=output_man_dim)
 
     def __hash__(self):
-        # TODO: need to change the hash based on the other ManifoldTensor properties as well.
-        return hash(self.tensor)
+        """Returns the Python unique identifier of the object.
+
+        Note: This is how PyTorch implements hash of tensors. See also:
+        https://github.com/pytorch/pytorch/issues/2569.
+
+        """
+        return id(self)
 
     def cpu(self) -> ManifoldTensor:
         """Returns a copy of this object with self.tensor in CPU memory."""

--- a/hypll/tensors/tangent_tensor.py
+++ b/hypll/tensors/tangent_tensor.py
@@ -88,6 +88,15 @@ class TangentTensor:
                 f"Neither {self.__class__.__name__}, nor torch.Tensor has attribute {name}"
             )
 
+    def __hash__(self):
+        """Returns the Python unique identifier of the object.
+
+        Note: This is how PyTorch implements hash of tensors. See also:
+        https://github.com/pytorch/pytorch/issues/2569.
+
+        """
+        return id(self)
+
     def cuda(self, device=None):
         new_tensor = self.tensor.cuda(device)
         new_manifold_points = self.manifold_points.cuda(device)


### PR DESCRIPTION
# Implement __hash__ for tensors as in torch

* Use `id` for `hash` as torch does it for tensors (there are no hash collisions).