### PR TITLE
Implement cat operation on Manifold classes.

### DIFF
--- a/hypll/manifolds/base/manifold.py
+++ b/hypll/manifolds/base/manifold.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from torch import Tensor
 from torch.nn import Module, Parameter
@@ -106,5 +106,13 @@ class Manifold(Module, ABC):
         dilation: _size_2_t = 1,
         padding: _size_2_t = 0,
         stride: _size_2_t = 1,
+    ) -> ManifoldTensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cat(
+        self,
+        manifold_tensors: Union[Tuple[ManifoldTensor, ...], List[ManifoldTensor]],
+        dim: int = 0,
     ) -> ManifoldTensor:
         raise NotImplementedError

--- a/hypll/manifolds/euclidean/manifold.py
+++ b/hypll/manifolds/euclidean/manifold.py
@@ -1,5 +1,5 @@
 from math import sqrt
-from typing import Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor, broadcast_shapes, empty, matmul, var
@@ -12,6 +12,7 @@ from hypll.manifolds.base import Manifold
 from hypll.tensors import ManifoldParameter, ManifoldTensor, TangentTensor
 from hypll.utils.tensor_utils import (
     check_dims_with_broadcasting,
+    check_if_man_dims_match,
     check_tangent_tensor_positions,
 )
 
@@ -223,3 +224,13 @@ class Euclidean(Manifold):
 
     def cdist(self, x: ManifoldTensor, y: ManifoldTensor) -> Tensor:
         return torch.cdist(x.tensor, y.tensor)
+
+    def cat(
+        self,
+        manifold_tensors: Union[Tuple[ManifoldTensor, ...], List[ManifoldTensor]],
+        dim: int = 0,
+    ) -> ManifoldTensor:
+        check_if_man_dims_match(manifold_tensors)
+        cat = torch.cat([t.tensor for t in manifold_tensors], dim=dim)
+        man_dim = manifold_tensors[0].man_dim
+        return ManifoldTensor(data=cat, manifold=self, man_dim=man_dim)

--- a/hypll/utils/math.py
+++ b/hypll/utils/math.py
@@ -1,6 +1,14 @@
 from math import exp, lgamma
+from typing import Union
+
+import torch
 
 
-def beta_func(a: int, b: int) -> float:
-    log_beta = lgamma(a) + lgamma(b) - lgamma(a + b)
-    return exp(log_beta)
+def beta_func(
+    a: Union[float, torch.Tensor], b: Union[float, torch.Tensor]
+) -> Union[float, torch.Tensor]:
+    if isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor):
+        a = torch.as_tensor(a) if not isinstance(a, torch.Tensor) else a
+        b = torch.as_tensor(b) if not isinstance(b, torch.Tensor) else b
+        return torch.exp(torch.lgamma(a) + torch.lgamma(b) - torch.lgamma(a + b))
+    return exp(lgamma(a) + lgamma(b) - lgamma(a + b))

--- a/hypll/utils/tensor_utils.py
+++ b/hypll/utils/tensor_utils.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, Union
+
 from torch import broadcast_shapes, equal
 
 from hypll.tensors import ManifoldTensor, TangentTensor
@@ -43,3 +45,22 @@ def check_tangent_tensor_positions(*args: TangentTensor) -> None:
                 raise ValueError(
                     f"Tangent tensors are positioned at the different points on the manifold"
                 )
+
+
+def check_if_man_dims_match(
+    manifold_tensors: Union[Tuple[ManifoldTensor, ...], List[ManifoldTensor]]
+) -> None:
+    iterator = iter(manifold_tensors)
+
+    try:
+        first_item = next(iterator)
+    except StopIteration:
+        return
+
+    for i, x in enumerate(iterator):
+        if x.man_dim != first_item.man_dim:
+            raise ValueError(
+                f"Manifold dimensions of inputs do not match. "
+                f"Input at index [0] has manifold dimension {first_item.man_dim} "
+                f"but input at index [{i + 1}] has manifold dimension {x.man_dim}."
+            )

--- a/tests/manifolds/euclidean/test_euclidean.py
+++ b/tests/manifolds/euclidean/test_euclidean.py
@@ -109,3 +109,24 @@ def test_cdist__correct_dims():
     mt2 = ManifoldTensor(torch.randn(B, R, M), manifold=manifold)
     dist_matrix = manifold.cdist(mt1, mt2)
     assert dist_matrix.shape == (B, P, R)
+
+
+def test_cat__correct_dims():
+    N, D1, D2 = 10, 2, 3
+    manifold = Euclidean()
+    manifold_tensors = [ManifoldTensor(torch.randn(D1, D2), manifold=manifold) for _ in range(N)]
+    cat_0 = manifold.cat(manifold_tensors, dim=0)
+    cat_1 = manifold.cat(manifold_tensors, dim=1)
+    assert cat_0.shape == (D1 * N, D2)
+    assert cat_1.shape == (D1, D2 * N)
+
+
+def test_cat__correct_man_dim():
+    N, D1, D2 = 10, 2, 3
+    manifold = Euclidean()
+    manifold_tensors = [
+        ManifoldTensor(torch.randn(D1, D2), manifold=manifold, man_dim=1) for _ in range(N)
+    ]
+    cat_0 = manifold.cat(manifold_tensors, dim=0)
+    cat_1 = manifold.cat(manifold_tensors, dim=1)
+    assert cat_0.man_dim == cat_1.man_dim == 1

--- a/tests/manifolds/poincare_ball/test_poincare_ball.py
+++ b/tests/manifolds/poincare_ball/test_poincare_ball.py
@@ -109,3 +109,35 @@ def test_cdist__correct_dims():
     mt2 = ManifoldTensor(torch.randn(B, R, M), manifold=manifold)
     dist_matrix = manifold.cdist(mt1, mt2)
     assert dist_matrix.shape == (B, P, R)
+
+
+def test_cat__correct_dims():
+    N, D1, D2 = 10, 2, 3
+    manifold = PoincareBall(c=Curvature())
+    manifold_tensors = [ManifoldTensor(torch.randn(D1, D2), manifold=manifold) for _ in range(N)]
+    cat_0 = manifold.cat(manifold_tensors, dim=0)
+    cat_1 = manifold.cat(manifold_tensors, dim=1)
+    assert cat_0.shape == (D1 * N, D2)
+    assert cat_1.shape == (D1, D2 * N)
+
+
+def test_cat__correct_man_dim():
+    N, D1, D2 = 10, 2, 3
+    manifold = PoincareBall(c=Curvature())
+    manifold_tensors = [
+        ManifoldTensor(torch.randn(D1, D2), manifold=manifold, man_dim=1) for _ in range(N)
+    ]
+    cat_0 = manifold.cat(manifold_tensors, dim=0)
+    cat_1 = manifold.cat(manifold_tensors, dim=1)
+    assert cat_0.man_dim == cat_1.man_dim == 1
+
+
+def test_cat__beta_concatenation_correct_norm():
+    MD = 64
+    manifold = PoincareBall(c=Curvature(0.1, constraining_strategy=lambda x: x))
+    t1 = torch.randn(MD)
+    t2 = torch.randn(MD)
+    mt1 = ManifoldTensor(t1 / t1.norm(), manifold=manifold)
+    mt2 = ManifoldTensor(t2 / t2.norm(), manifold=manifold)
+    cat = manifold.cat([mt1, mt2])
+    assert torch.isclose(cat.tensor.norm(), torch.as_tensor(1.0), atol=1e-2)


### PR DESCRIPTION
I have added an extra test `test_cat__beta_concatenation_correct_norm` for beta-concatenation. The argument `atol` can be smaller as `MD` increases, so the values `MD=64` and `atol=1e-2` are rather arbitrary. If this is too hacky or redundant, let's remove/change the test.