### PR TITLE
62 curvature in poincareball hardcoded as float32 torch tensor

### DIFF
--- a/hypll/manifolds/poincare_ball/curvature.py
+++ b/hypll/manifolds/poincare_ball/curvature.py
@@ -31,7 +31,7 @@ class Curvature(Module):
     ):
         super(Curvature, self).__init__()
         self.value = Parameter(
-            data=as_tensor(value, dtype=torch.float32),
+            data=as_tensor(value),
             requires_grad=requires_grad,
         )
         self.constraining_strategy = constraining_strategy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hypll"
-version = "0.1.1"
+version = "0.1.2"
 description = "A framework for hyperbolic learning in PyTorch"
 authors = ["Max van Spengler", "Philipp Wirth", "Pascal Mettes"]
 


### PR DESCRIPTION
Removed the hard-coded dtype from the curvature initialization.